### PR TITLE
Update icecast2

### DIFF
--- a/icecast2/agents/plugins/icecast2
+++ b/icecast2/agents/plugins/icecast2
@@ -54,7 +54,7 @@ do
     if [ $LISTENIP == "0.0.0.0" ]; then
         LISTENIP="127.0.0.1"
     fi
-    RESULT=`curl http://${LISTENIP}:${PORT}/status-json.xsl -A Mozilla/4.0 -s -I | grep Icecast`
+    RESULT=`curl http://${LISTENIP}:${PORT}/status-json.xsl -A Mozilla/4.0 -s -I | grep 'Icecast\|icecast'`
     if [[ ! $(tr -d "\r\n" <<< $RESULT | wc -c) -eq 0 ]]; then
         RESULT=`curl http://${LISTENIP}:${PORT}/status-json.xsl -A Mozilla/4.0 -s`
         TARGETPROP='listener_peak'


### PR DESCRIPTION
Icecast2 from debian backports report as "Server: icecast", since agent grep for 'Icecast' it fails with finding any servers. Adjusted grep to accept both lower and uppercase.